### PR TITLE
Adopt `prompt_toolkit` and support concurrent clients

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -37,13 +37,8 @@ Monitor has context manager interface:
 
 Now from separate terminal it is possible to connect to the application::
 
-    $ nc localhost 50101
-    
+    $ telnet localhost 50101
 
-To make arrow keys working properly you can use the `rlwrap` trick:
-
-    $ rlwrap nc localhost 50101
-    
 
 or the included python client::
 

--- a/aiomonitor/cli.py
+++ b/aiomonitor/cli.py
@@ -1,9 +1,5 @@
 import argparse
 import asyncio
-import os
-import shutil
-import struct
-import telnetlib
 
 from .monitor import MONITOR_HOST, MONITOR_PORT
 from .telnet import TelnetClient

--- a/aiomonitor/cli.py
+++ b/aiomonitor/cli.py
@@ -1,22 +1,57 @@
 import argparse
+import os
+import shutil
+import struct
+import sys
 import telnetlib
 
 from .monitor import MONITOR_HOST, MONITOR_PORT
 
 
+def opt_callback(sock, command, option):
+    if command == telnetlib.DO and option == b'\x18':  # terminal type
+        sock.send(b''.join([
+            telnetlib.IAC,
+            telnetlib.WILL,
+            b'\x18',
+            telnetlib.IAC,
+            telnetlib.SB,
+            b'\x18\x00',
+            os.environ.get('TERM', 'xterm').encode('ascii'),
+            telnetlib.IAC,
+            telnetlib.SE,
+        ]))
+    elif command == telnetlib.DO and option == b'\x1f':  # window size
+        term_size = shutil.get_terminal_size()
+        sock.send(b''.join([
+            telnetlib.IAC,
+            telnetlib.WILL,
+            b'\x1f',
+            telnetlib.IAC,
+            telnetlib.SB,
+            b'\x1f',
+            struct.pack('>HH', term_size.columns, term_size.lines),
+            telnetlib.IAC,
+            telnetlib.SE,
+        ]))
+    else:
+        print("OPT_CALLBACK", sock, command, option, file=sys.stderr)
+
+
 def monitor_client(host: str, port: int) -> None:
     tn = telnetlib.Telnet()
+    tn.set_option_negotiation_callback(opt_callback)
     tn.open(host, port, timeout=1)
     try:
         tn.interact()
-    except KeyboardInterrupt:
+    except (EOFError, KeyboardInterrupt):
         pass
     finally:
         tn.close()
 
 
 def main() -> None:
-    parser = argparse.ArgumentParser("usage: python -m aiomonitor [options]")
+    parser = argparse.ArgumentParser()
     parser.add_argument(
         "-H",
         "--host",
@@ -25,7 +60,6 @@ def main() -> None:
         type=str,
         help="monitor host ip",
     )
-
     parser.add_argument(
         "-p",
         "--port",

--- a/aiomonitor/monitor.py
+++ b/aiomonitor/monitor.py
@@ -227,6 +227,7 @@ class Monitor:
         tasknum = len(all_tasks(loop=self._monitored_loop))
         s = "" if tasknum == 1 else "s"
         self._sout.write(self.intro.format(tasknum=tasknum, s=s))
+        await asyncio.sleep(0.3)
         prompt_session = prompt_toolkit.PromptSession(self.prompt)
         while True:
             try:

--- a/aiomonitor/monitor.py
+++ b/aiomonitor/monitor.py
@@ -223,11 +223,11 @@ class Monitor:
 
     async def _interact(self, connection: TelnetConnection) -> None:
         """Main interactive loop of the monitor"""
+        await asyncio.sleep(0.3)  # wait until telnet negotiation is done
         self._sout = connection.stdout
         tasknum = len(all_tasks(loop=self._monitored_loop))
         s = "" if tasknum == 1 else "s"
         self._sout.write(self.intro.format(tasknum=tasknum, s=s))
-        await asyncio.sleep(0.3)
         prompt_session = prompt_toolkit.PromptSession(self.prompt)
         while True:
             try:

--- a/aiomonitor/monitor.py
+++ b/aiomonitor/monitor.py
@@ -5,7 +5,6 @@ import inspect
 import logging
 import os
 import signal
-import socket
 import sys
 import threading
 import time
@@ -17,7 +16,7 @@ from contextlib import suppress
 from datetime import timedelta
 from types import TracebackType
 from typing import (
-    IO,
+    TextIO,
     Any,
     Callable,
     Generator,
@@ -29,6 +28,8 @@ from typing import (
     Type,
 )
 
+import prompt_toolkit
+from prompt_toolkit.contrib.telnet.server import TelnetServer, TelnetConnection
 from terminaltables import AsciiTable
 
 from .mypy_types import Loop, OptLocals
@@ -94,8 +95,7 @@ class Monitor:
         "    {cmd_name}{cmd_arg_sep}{arg_list}: {doc_firstline}"  # noqa
     )
 
-    _sin: IO[str] | None = None
-    _sout: IO[str] | None = None
+    _sout: TextIO
     _created_traceback_chains: weakref.WeakKeyDictionary[
         asyncio.Task[Any],
         asyncio.Task[Any],
@@ -122,7 +122,7 @@ class Monitor:
         hook_task_factory: bool = False,
         locals: OptLocals = None,
     ) -> None:
-        self._loop = loop or asyncio.get_event_loop()
+        self._monitored_loop = loop or asyncio.get_event_loop()
         self._host = host
         self._port = port
         self._console_port = console_port
@@ -132,7 +132,6 @@ class Monitor:
         log.info("Starting aiomonitor at %s:%d", host, port)
 
         self._ui_thread = threading.Thread(target=self._server, args=(), daemon=True)
-        self._closing = threading.Event()
         self._closed = False
         self._started = False
         self._console_future = None  # type: Optional[Future[Any]]
@@ -156,9 +155,9 @@ class Monitor:
         assert not self._started
 
         self._started = True
-        self._original_task_factory = self._loop.get_task_factory()
+        self._original_task_factory = self._monitored_loop.get_task_factory()
         if self._hook_task_factory:
-            self._loop.set_task_factory(self._create_task)
+            self._monitored_loop.set_task_factory(self._create_task)
         self._event_loop_thread_id = threading.get_ident()
         self._ui_thread.start()
 
@@ -183,19 +182,22 @@ class Monitor:
         self.close()
 
     def close(self) -> None:
+        assert self._started, "The monitor must have been started to close it."
         if not self._closed:
-            self._closing.set()
+            self._telnet_server_loop.call_soon_threadsafe(
+                self._telnet_server_future.cancel,
+            )
             self._ui_thread.join()
-            self._loop.set_task_factory(self._original_task_factory)
+            self._monitored_loop.set_task_factory(self._original_task_factory)
             self._closed = True
 
     def _create_task(self, loop, coro) -> asyncio.Task:
-        assert loop is self._loop
+        assert loop is self._monitored_loop
         try:
             parent_task = asyncio.current_task()
         except RuntimeError:
             parent_task = None
-        task = TracedTask(coro, loop=self._loop)
+        task = TracedTask(coro, loop=self._monitored_loop)
         self._created_tracebacks[task] = _extract_stack_from_frame(sys._getframe())[
             :-1
         ]  # strip this wrapper method
@@ -204,67 +206,53 @@ class Monitor:
         return task
 
     def _server(self) -> None:
-        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        telnet_server = TelnetServer(interact=self._interact, host=self._host, port=self._port)
+        asyncio.run(self._server_async(telnet_server))
+
+    async def _server_async(self, telnet_server: TelnetServer) -> None:
+        loop = asyncio.get_running_loop()
+        self._telnet_server_loop = loop
+        self._telnet_server_future = loop.create_future()
+        telnet_server.start()
         try:
-            sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEPORT, 1)
-        except AttributeError:
+            await self._telnet_server_future
+        except asyncio.CancelledError:
             pass
+        finally:
+            await telnet_server.stop()
 
-        # set the timeout to prevent the server loop from
-        # blocking indefinitaly on sock.accept()
-        sock.settimeout(0.5)
-        sock.bind((self._host, self._port))
-        sock.listen(1)
-        with sock:
-            while not self._closing.is_set():
-                try:
-                    client, addr = sock.accept()
-                    with client:
-                        sout = client.makefile("w", encoding="utf-8")
-                        sin = client.makefile("r", encoding="utf-8")
-                        self._interactive_loop(sin, sout)
-                except (socket.timeout, OSError):
-                    continue
-
-    def _interactive_loop(self, sin: IO[str], sout: IO[str]) -> None:
+    async def _interact(self, connection: TelnetConnection) -> None:
         """Main interactive loop of the monitor"""
-        self._sin = sin
-        self._sout = sout
-        tasknum = len(all_tasks(loop=self._loop))
+        self._sout = connection.stdout
+        tasknum = len(all_tasks(loop=self._monitored_loop))
         s = "" if tasknum == 1 else "s"
         self._sout.write(self.intro.format(tasknum=tasknum, s=s))
-        try:
-            while not self._closing.is_set():
-                self._sout.write(self.prompt)
+        prompt_session = prompt_toolkit.PromptSession(self.prompt)
+        while True:
+            try:
+                user_input = await prompt_session.prompt_async()
+            except (EOFError, KeyboardInterrupt):
+                return
+            except Exception as e:
+                msg = "Could not read from user input due to:\n{}\n"
+                log.exception(msg)
+                self._sout.write(msg.format(repr(e)))
                 self._sout.flush()
+            else:
                 try:
-                    user_input = sin.readline()
-                    if not user_input:
-                        break
-                    user_input = user_input.strip()
+                    self._command_dispatch(user_input)
                 except Exception as e:
-                    msg = "Could not read from user input due to:\n{}\n"
+                    msg = "Unexpected Exception during command execution:\n{}\n"  # noqa
                     log.exception(msg)
                     self._sout.write(msg.format(repr(e)))
                     self._sout.flush()
-                else:
-                    try:
-                        self._command_dispatch(user_input)
-                    except Exception as e:
-                        msg = "Unexpected Exception during command execution:\n{}\n"  # noqa
-                        log.exception(msg)
-                        self._sout.write(msg.format(repr(e)))
-                        self._sout.flush()
-        finally:
-            self._sin = None  # type: ignore
-            self._sout = None  # type: ignore
 
     def _command_dispatch(self, user_input: str) -> None:
         if not user_input:
             return self.emptyline()
         assert self._sout is not None
 
+        result = None
         self.lastcmd = user_input
         comm, *args = user_input.split(" ")
         try:
@@ -431,7 +419,7 @@ class Monitor:
         table_data: List[Tuple[str, str, str, str, str, str]] = [headers]
         assert self._sout is not None
 
-        for task in sorted(all_tasks(loop=self._loop), key=id):
+        for task in sorted(all_tasks(loop=self._monitored_loop), key=id):
             taskid = str(id(task))
             if task:
                 coro = _format_coroutine(task.get_coro()).partition(" ")[0]
@@ -476,7 +464,7 @@ class Monitor:
         """Show stack frames and its task creation chain of a task"""
         assert self._sout is not None
         depth = 0
-        task = task_by_id(taskid, self._loop)
+        task = task_by_id(taskid, self._monitored_loop)
         if task is None:
             self._sout.write("No task %d\n" % taskid)
             return
@@ -538,9 +526,9 @@ class Monitor:
     def do_cancel(self, taskid: int) -> None:
         """Cancel an indicated task"""
         assert self._sout is not None
-        task = task_by_id(taskid, self._loop)
+        task = task_by_id(taskid, self._monitored_loop)
         if task:
-            fut = asyncio.run_coroutine_threadsafe(cancel_task(task), loop=self._loop)
+            fut = asyncio.run_coroutine_threadsafe(cancel_task(task), loop=self._monitored_loop)
             fut.result(timeout=3)
             self._sout.write("Cancel task %d\n" % taskid)
         else:
@@ -565,14 +553,14 @@ class Monitor:
         h, p = self._host, self._console_port
         log.info("Starting console at %s:%d", h, p)
         fut = init_console_server(
-            self._host, self._console_port, self._locals, self._loop
+            self._host, self._console_port, self._locals, self._monitored_loop
         )
         server = fut.result(timeout=3)
         try:
             console_proxy(self._sin, self._sout, self._host, self._console_port)
         finally:
             coro = close_server(server)
-            close_fut = asyncio.run_coroutine_threadsafe(coro, loop=self._loop)
+            close_fut = asyncio.run_coroutine_threadsafe(coro, loop=self._monitored_loop)
             close_fut.result(timeout=15)
 
 

--- a/aiomonitor/monitor.py
+++ b/aiomonitor/monitor.py
@@ -206,13 +206,13 @@ class Monitor:
         return task
 
     def _server(self) -> None:
-        telnet_server = TelnetServer(interact=self._interact, host=self._host, port=self._port)
-        asyncio.run(self._server_async(telnet_server))
+        asyncio.run(self._server_async())
 
-    async def _server_async(self, telnet_server: TelnetServer) -> None:
+    async def _server_async(self) -> None:
         loop = asyncio.get_running_loop()
         self._telnet_server_loop = loop
         self._telnet_server_future = loop.create_future()
+        telnet_server = TelnetServer(interact=self._interact, host=self._host, port=self._port)
         telnet_server.start()
         try:
             await self._telnet_server_future

--- a/aiomonitor/monitor.py
+++ b/aiomonitor/monitor.py
@@ -16,7 +16,6 @@ from contextlib import suppress
 from datetime import timedelta
 from types import TracebackType
 from typing import (
-    TextIO,
     Any,
     Callable,
     Generator,
@@ -24,12 +23,13 @@ from typing import (
     NamedTuple,
     Optional,
     Sequence,
+    TextIO,
     Tuple,
     Type,
 )
 
 from prompt_toolkit import PromptSession
-from prompt_toolkit.contrib.telnet.server import TelnetServer, TelnetConnection
+from prompt_toolkit.contrib.telnet.server import TelnetConnection, TelnetServer
 from terminaltables import AsciiTable
 
 from .mypy_types import Loop, OptLocals

--- a/aiomonitor/monitor.py
+++ b/aiomonitor/monitor.py
@@ -28,7 +28,7 @@ from typing import (
     Type,
 )
 
-import prompt_toolkit
+from prompt_toolkit import PromptSession
 from prompt_toolkit.contrib.telnet.server import TelnetServer, TelnetConnection
 from terminaltables import AsciiTable
 
@@ -228,10 +228,10 @@ class Monitor:
         tasknum = len(all_tasks(loop=self._monitored_loop))
         s = "" if tasknum == 1 else "s"
         self._sout.write(self.intro.format(tasknum=tasknum, s=s))
-        prompt_session = prompt_toolkit.PromptSession(self.prompt)
+        prompt_session: PromptSession[str] = PromptSession(self.prompt)
         while True:
             try:
-                user_input = await prompt_session.prompt_async()
+                user_input = (await prompt_session.prompt_async()).strip()
             except (EOFError, KeyboardInterrupt):
                 return
             except Exception as e:

--- a/aiomonitor/monitor.py
+++ b/aiomonitor/monitor.py
@@ -212,7 +212,9 @@ class Monitor:
         loop = asyncio.get_running_loop()
         self._telnet_server_loop = loop
         self._telnet_server_future = loop.create_future()
-        telnet_server = TelnetServer(interact=self._interact, host=self._host, port=self._port)
+        telnet_server = TelnetServer(
+            interact=self._interact, host=self._host, port=self._port
+        )
         telnet_server.start()
         try:
             await self._telnet_server_future
@@ -529,7 +531,9 @@ class Monitor:
         assert self._sout is not None
         task = task_by_id(taskid, self._monitored_loop)
         if task:
-            fut = asyncio.run_coroutine_threadsafe(cancel_task(task), loop=self._monitored_loop)
+            fut = asyncio.run_coroutine_threadsafe(
+                cancel_task(task), loop=self._monitored_loop
+            )
             fut.result(timeout=3)
             self._sout.write("Cancel task %d\n" % taskid)
         else:
@@ -561,7 +565,9 @@ class Monitor:
             console_proxy(self._sin, self._sout, self._host, self._console_port)
         finally:
             coro = close_server(server)
-            close_fut = asyncio.run_coroutine_threadsafe(coro, loop=self._monitored_loop)
+            close_fut = asyncio.run_coroutine_threadsafe(
+                coro, loop=self._monitored_loop
+            )
             close_fut.result(timeout=15)
 
 

--- a/aiomonitor/telnet.py
+++ b/aiomonitor/telnet.py
@@ -12,7 +12,7 @@ from typing import Dict, Optional, Tuple
 
 
 ModeDef = collections.namedtuple(
-    "mode", ["iflag", "oflag", "cflag", "lflag", "ispeed", "ospeed", "cc"]
+    "ModeDef", ["iflag", "oflag", "cflag", "lflag", "ispeed", "ospeed", "cc"]
 )
 
 
@@ -120,6 +120,7 @@ class TelnetClient:
                 pass
         finally:
             self.restore_mode()
+            return None
 
     async def interact(self) -> None:
         try:

--- a/aiomonitor/telnet.py
+++ b/aiomonitor/telnet.py
@@ -1,0 +1,200 @@
+from __future__ import annotations
+
+import asyncio
+import collections
+import fcntl
+import os
+import termios
+import struct
+import sys
+import telnetlib
+from typing import Dict, Optional, Tuple
+
+
+ModeDef = collections.namedtuple(
+    "mode", ["iflag", "oflag", "cflag", "lflag", "ispeed", "ospeed", "cc"]
+)
+
+
+class TelnetClient:
+
+    def __init__(self, host: str, port: int) -> None:
+        self._host = host
+        self._port = port
+        self._term = os.environ.get("TERM", "unknown")
+        self._stdin = sys.stdin
+        self._stdout = sys.stdout
+        self._isatty = os.path.sameopenfile(self._stdin.fileno(), self._stdout.fileno())
+        self._remote_options: Dict[bytes, bool] = collections.defaultdict(lambda: False)
+
+    async def _create_stdio_streams(self) -> Tuple[asyncio.StreamReader, asyncio.StreamWriter]:
+        loop = asyncio.get_running_loop()
+        stdin_reader = asyncio.StreamReader()
+        stdin_protocol = asyncio.StreamReaderProtocol(stdin_reader)
+        await loop.connect_read_pipe(lambda: stdin_protocol, self._stdin)
+        write_target = self._stdin if self._isatty else self._stdout
+        writer_transport, writer_protocol = await loop.connect_write_pipe(
+            asyncio.streams.FlowControlMixin,
+            write_target,
+        )
+        stdout_writer = asyncio.StreamWriter(writer_transport, writer_protocol, None, loop)
+        return stdin_reader, stdout_writer
+
+    def get_mode(self) -> Optional[ModeDef]:
+        if self._isatty:
+            return ModeDef(*termios.tcgetattr(self._stdin.fileno()))
+        return None
+
+    def set_mode(self, mode: ModeDef) -> None:
+        termios.tcsetattr(sys.stdin.fileno(), termios.TCSAFLUSH, list(mode))
+
+    def restore_mode(self) -> None:
+        if self._isatty and self._saved_mode is not None:
+            termios.tcsetattr(
+                self._stdin.fileno(), termios.TCSAFLUSH, list(self._saved_mode)
+            )
+
+    def determine_mode(self, mode: ModeDef) -> ModeDef:
+        # Reference: https://github.com/jquast/telnetlib3/blob/b90616f/telnetlib3/client_shell.py#L76
+        if not self._remote_options[telnetlib.ECHO]:
+            return mode
+        iflag = mode.iflag & ~(
+            termios.BRKINT
+            | termios.ICRNL  # Do not send INTR signal on break
+            | termios.INPCK  # Do not map CR to NL on input
+            | termios.ISTRIP  # Disable input parity checking
+            | termios.IXON  # Do not strip input characters to 7 bits
+        )
+        cflag = mode.cflag & ~(termios.CSIZE | termios.PARENB)
+        cflag = cflag | termios.CS8
+        lflag = mode.lflag & ~(
+            termios.ICANON | termios.IEXTEN | termios.ISIG | termios.ECHO
+        )
+        oflag = mode.oflag & ~(termios.OPOST | termios.ONLCR)
+        cc = list(mode.cc)
+        cc[termios.VMIN] = 1
+        cc[termios.VTIME] = 0
+        return ModeDef(
+            iflag=iflag,
+            oflag=oflag,
+            cflag=cflag,
+            lflag=lflag,
+            ispeed=mode.ispeed,
+            ospeed=mode.ospeed,
+            cc=cc,
+        )
+
+    async def __aenter__(self) -> TelnetClient:
+        self._conn_reader, self._conn_writer = await asyncio.open_connection(self._host, self._port)
+        self._closed = asyncio.Event()
+        self._stdin_reader, self._stdout_writer = await self._create_stdio_streams()
+        self._read_task = asyncio.create_task(self._read())
+        self._input_task = asyncio.create_task(self._input())
+        self._saved_mode = self.get_mode()
+        await asyncio.sleep(0.3)  # add some time for negotiation
+        if self._isatty:
+            assert self._saved_mode is not None
+            self.set_mode(self.determine_mode(self._saved_mode))
+        return self
+
+    async def __aexit__(self, *exc_info) -> Optional[bool]:
+        try:
+            self._input_task.cancel()
+            await self._input_task
+            self._conn_writer.close()
+            try:
+                await self._conn_writer.wait_closed()
+            except NotImplementedError:
+                pass
+            self._conn_reader.feed_eof()
+            await self._read_task
+            self._stdout_writer.close()
+            try:
+                await self._stdout_writer.wait_closed()
+            except NotImplementedError:
+                pass
+        finally:
+            self.restore_mode()
+
+    async def interact(self) -> None:
+        try:
+            await self._closed.wait()
+        except KeyboardInterrupt:
+            self._conn_writer.write_eof()
+            self._closed.set()
+            raise
+
+    async def _input(self) -> None:
+        try:
+            while True:
+                buf = await self._stdin_reader.read(128)
+                self._conn_writer.write(buf)
+                await self._conn_writer.drain()
+        except asyncio.CancelledError:
+            pass
+
+    async def _handle_nego(self, command: bytes, option: bytes) -> None:
+        if command == telnetlib.DO and option == telnetlib.TTYPE:
+            self._conn_writer.write(telnetlib.IAC + telnetlib.WILL + telnetlib.TTYPE)
+            self._conn_writer.write(telnetlib.IAC + telnetlib.SB + telnetlib.TTYPE)
+            self._conn_writer.write(telnetlib.BINARY + self._term.encode("ascii"))
+            self._conn_writer.write(telnetlib.IAC + telnetlib.SE)
+            await self._conn_writer.drain()
+        elif command == telnetlib.DO and option == telnetlib.NAWS:
+            self._conn_writer.write(telnetlib.IAC + telnetlib.WILL + telnetlib.NAWS)
+            self._conn_writer.write(telnetlib.IAC + telnetlib.SB + telnetlib.NAWS)
+            fmt = "HHHH"
+            buf = b"\x00" * struct.calcsize(fmt)
+            buf = fcntl.ioctl(self._stdin.fileno(), termios.TIOCGWINSZ, buf)
+            rows, cols, _, _ = struct.unpack(fmt, buf)
+            self._conn_writer.write(struct.pack(">HH", cols, rows))
+            self._conn_writer.write(telnetlib.IAC + telnetlib.SE)
+            await self._conn_writer.drain()
+        elif command == telnetlib.WILL:
+            self._remote_options[option] = True
+        elif command == telnetlib.WONT:
+            self._remote_options[option] = False
+
+    async def _handle_sb(self, option: bytes, chunk: bytes) -> None:
+        pass
+
+    async def _read(self):
+        buf = b""
+        try:
+            while not self._conn_reader.at_eof():
+                buf += await self._conn_reader.read(64)
+                while buf:
+                    cmd_begin = buf.find(telnetlib.IAC)
+                    if cmd_begin == -1:
+                        self._stdout_writer.write(buf)
+                        await self._stdout_writer.drain()
+                        buf = b""
+                    else:
+                        if cmd_begin >= len(buf) - 2:
+                            buf += await self._conn_reader.readexactly(
+                                3 - (len(buf) - cmd_begin),
+                            )
+                        command = buf[cmd_begin + 1:cmd_begin + 2]
+                        option = buf[cmd_begin + 2:cmd_begin + 3]
+                        buf_before, buf_after = buf[:cmd_begin], buf[cmd_begin + 3:]
+                        self._stdout_writer.write(buf_before)
+                        await self._stdout_writer.drain()
+                        if command in (
+                            telnetlib.WILL,
+                            telnetlib.WONT,
+                            telnetlib.DO,
+                            telnetlib.DONT,
+                        ):
+                            await self._handle_nego(command, option)
+                        elif command == telnetlib.SB:
+                            subnego_end = buf_after.find(telnetlib.IAC + telnetlib.SE)
+                            if subnego_end == -1:
+                                subnego_chunk = buf_after + (await self._conn_reader.readuntil(telnetlib.IAC + telnetlib.SE))[:-2]
+                                buf_after = b""
+                            else:
+                                subnego_chunk = buf_after[:subnego_end]
+                                buf_after = buf_after[subnego_end + 2:]
+                            await self._handle_sb(option, subnego_chunk)
+                        buf = buf_after
+        finally:
+            self._closed.set()

--- a/aiomonitor/telnet.py
+++ b/aiomonitor/telnet.py
@@ -125,7 +125,7 @@ class TelnetClient:
                 pass
         finally:
             self.restore_mode()
-            return None
+        return None
 
     async def interact(self) -> None:
         try:

--- a/aiomonitor/telnet.py
+++ b/aiomonitor/telnet.py
@@ -17,6 +17,11 @@ ModeDef = collections.namedtuple(
 
 
 class TelnetClient:
+    """
+    A minimal telnet client-side protocol implementation to support `prompt_toolkit`.
+    Some details like terminal mode handling is taken from telnetlib3.
+    (https://github.com/jquast/telnetlib3)
+    """
 
     def __init__(self, host: str, port: int) -> None:
         self._host = host
@@ -90,7 +95,7 @@ class TelnetClient:
         self._stdin_reader, self._stdout_writer = await self._create_stdio_streams()
         self._read_task = asyncio.create_task(self._read())
         self._input_task = asyncio.create_task(self._input())
-        await asyncio.sleep(0.3)  # add some time for negotiation
+        await asyncio.sleep(0.3)  # wait for negotiation to complete
         self._saved_mode = self.get_mode()
         if self._isatty:
             assert self._saved_mode is not None
@@ -167,7 +172,7 @@ class TelnetClient:
         buf = b""
         try:
             while not self._conn_reader.at_eof():
-                buf += await self._conn_reader.read(64)
+                buf += await self._conn_reader.read(128)
                 while buf:
                     cmd_begin = buf.find(telnetlib.IAC)
                     if cmd_begin == -1:

--- a/aiomonitor/telnet.py
+++ b/aiomonitor/telnet.py
@@ -4,12 +4,11 @@ import asyncio
 import collections
 import fcntl
 import os
-import termios
 import struct
 import sys
 import telnetlib
+import termios
 from typing import Dict, Optional, Tuple
-
 
 ModeDef = collections.namedtuple(
     "ModeDef", ["iflag", "oflag", "cflag", "lflag", "ispeed", "ospeed", "cc"]

--- a/examples/simple_aiohttp_srv.py
+++ b/examples/simple_aiohttp_srv.py
@@ -1,4 +1,5 @@
 import asyncio
+import logging
 
 import uvloop
 from aiohttp import web
@@ -30,5 +31,8 @@ async def main():
         await web._run_app(app, port=8090, host="localhost")
 
 
-uvloop.install()
-asyncio.run(main())
+if __name__ == "__main__":
+    logging.basicConfig()
+    logging.getLogger('aiomonitor').setLevel(logging.DEBUG)
+    uvloop.install()
+    asyncio.run(main())

--- a/examples/simple_aiohttp_srv.py
+++ b/examples/simple_aiohttp_srv.py
@@ -33,6 +33,6 @@ async def main():
 
 if __name__ == "__main__":
     logging.basicConfig()
-    logging.getLogger('aiomonitor').setLevel(logging.DEBUG)
+    logging.getLogger("aiomonitor").setLevel(logging.DEBUG)
     uvloop.install()
     asyncio.run(main())

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@ def read(f):
 
 install_requires = [
     "terminaltables",
+    "prompt_toolkit>=3.0",
     "aioconsole",
 ]
 extras_require: Dict[str, str] = {}


### PR DESCRIPTION
* Use `prompt_toolkit` to provide interactive, async telnet sessions with rihch features
  including command history, auto-completion, etc. 

BREAKING CHANGE:
* Now clients must handle the telnet protocol properly to get the rich prompt support.