### PR TITLE
fix: Regression in Python 3.10 due to task factory update for Python 3.11

### DIFF
--- a/aiomonitor/task.py
+++ b/aiomonitor/task.py
@@ -39,6 +39,8 @@ class TracedTask(asyncio.Task):
         persistent: bool = False,
         **kwargs,
     ) -> None:
+        if sys.version_info < (3, 11):
+            kwargs.pop("context")
         super().__init__(*args, **kwargs)
         self._termination_info_queue = termination_info_queue
         self._cancellation_chain_queue = cancellation_chain_queue


### PR DESCRIPTION
`asyncio.create_task()`'s optional `context` kwarg is added in Python 3.11.
We need to remove it explicitly when calling `super().__init__(...)` in `TracedTask'`s constructor for Python 3.10 and lower.